### PR TITLE
bump preview image size limit to 10M

### DIFF
--- a/apply-patches.sh
+++ b/apply-patches.sh
@@ -19,6 +19,9 @@ git apply "${CURRENT_PWD}/higher-feed-count.diff"
 git apply -R "${CURRENT_PWD}/pixiv-preview-with-embed-url.diff" || echo "this is idempotent"
 git apply "${CURRENT_PWD}/pixiv-preview-with-embed-url.diff"
 
+git apply -R "${CURRENT_PWD}/higher-preview-size-limit.diff" || echo "this is idempotent"
+git apply "${CURRENT_PWD}/higher-preview-size-limit.diff"
+
 git status
 git diff
 

--- a/higher-preview-size-limit.diff
+++ b/higher-preview-size-limit.diff
@@ -1,0 +1,15 @@
+diff --git a/app/models/preview_card.rb b/app/models/preview_card.rb
+index a6ec839f8..cbb9c8c31 100644
+--- a/app/models/preview_card.rb
++++ b/app/models/preview_card.rb
+@@ -27,9 +27,9 @@
+ #
+ 
+ class PreviewCard < ApplicationRecord
+   IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/gif'].freeze
+-  LIMIT = 1.megabytes
++  LIMIT = 10.megabytes
+ 
+   BLURHASH_OPTIONS = {
+     x_comp: 4,
+     y_comp: 4,


### PR DESCRIPTION
Just had a look at a few failed twitter previews and the image sizes all fell into the (1.0M,2.0M] range.